### PR TITLE
Test roles on Ubuntu 22.04

### DIFF
--- a/.github/ansible/playbook-ci.yml
+++ b/.github/ansible/playbook-ci.yml
@@ -41,6 +41,17 @@
     - role: "artyorsh.selfhosted.changedetection"
       tags: ["changedetection"]
 
+    - role: "artyorsh.selfhosted.cloudflare"
+      vars:
+        cloudflare_tunnel_uuid_or_name: "test-tunnel-name"
+      tags: ["cloudflare"]
+
+    - role: "artyorsh.selfhosted.duplicati"
+      vars:
+        duplicati_env:
+          SETTINGS_ENCRYPTION_KEY: "supersecret"
+      tags: ["duplicati"]
+
     - role: "artyorsh.selfhosted.duplicati"
       vars:
         duplicati_env:

--- a/.github/ansible/playbook-ci.yml
+++ b/.github/ansible/playbook-ci.yml
@@ -13,17 +13,6 @@
       pgid: "{{ user_gid }}"
 
   roles:
-    - role: "artyorsh.selfhosted.cloudflare"
-      vars:
-        cloudflare_tunnel_uuid_or_name: "test-tunnel-name"
-      tags: ["cloudflare"]
-
-    - role: "artyorsh.selfhosted.duplicati"
-      vars:
-        duplicati_env:
-          SETTINGS_ENCRYPTION_KEY: "supersecret"
-      tags: ["duplicati"]
-
     - role: "artyorsh.selfhosted.duplicati"
       vars:
         duplicati_env:

--- a/.github/ansible/playbook-ci.yml
+++ b/.github/ansible/playbook-ci.yml
@@ -9,9 +9,9 @@
 
   vars:
     docker_settings:
-      network: "docker-ci-network"
-      puid: "{{ user_uid }}"
-      pgid: "{{ user_gid }}"
+      network: "{{ network }}"
+      puid: "{{ puid }}"
+      pgid: "{{ pgid }}"
       healthcheck:
         start_period: 5s
         interval: 30s

--- a/.github/ansible/playbook-ci.yml
+++ b/.github/ansible/playbook-ci.yml
@@ -21,7 +21,8 @@
             admin:
               displayname: "Admin"
               email: "admin@{{ domain }}"
-              password: "$argon2id$v=19$m=1024,t=1,p=supersecret"
+              # supersecret, salt=supersecret
+              password: "$argon2id$v=19$m=1024,t=1,p=8$c3VwZXJzZWNyZXQ$3DK6bsCIIa3MWorb4zatsQ"
               groups: ["admins"]
 
         authelia_config:

--- a/.github/ansible/playbook-ci.yml
+++ b/.github/ansible/playbook-ci.yml
@@ -13,6 +13,9 @@
       pgid: "{{ user_gid }}"
 
   roles:
+    - role: "artyorsh.selfhosted.adguardhome"
+      tags: ["adguardhome"]
+
     - role: "artyorsh.selfhosted.duplicati"
       vars:
         duplicati_env:

--- a/.github/ansible/playbook-ci.yml
+++ b/.github/ansible/playbook-ci.yml
@@ -29,4 +29,7 @@
       tags: ["paperless_ai"]
 
     - role: "artyorsh.selfhosted.paperlessngx"
+      vars:
+        paperlessngx_docker_settings:
+          network: "docker-ci-network"
       tags: ["paperlessngx"]

--- a/.github/ansible/playbook-ci.yml
+++ b/.github/ansible/playbook-ci.yml
@@ -36,6 +36,9 @@
           pgid: "{{ user_gid }}"
       tags: ["nginx"]
 
+    - role: "artyorsh.selfhosted.olivetin"
+      tags: ["olivetin"]
+
     - role: "artyorsh.selfhosted.paperless_ai"
       tags: ["paperless_ai"]
 

--- a/.github/ansible/playbook-ci.yml
+++ b/.github/ansible/playbook-ci.yml
@@ -31,6 +31,9 @@
     - role: "artyorsh.selfhosted.homarr"
       tags: ["homarr"]
 
+    - role: "artyorsh.selfhosted.homebox"
+      tags: ["homebox"]
+
     - role: "artyorsh.selfhosted.nginx"
       vars:
         nginx_docker_settings:

--- a/.github/ansible/playbook-ci.yml
+++ b/.github/ansible/playbook-ci.yml
@@ -13,9 +13,6 @@
       pgid: "{{ user_gid }}"
 
   roles:
-    - role: "artyorsh.selfhosted.adguardhome"
-      tags: ["adguardhome"]
-
     - role: "artyorsh.selfhosted.duplicati"
       vars:
         duplicati_env:

--- a/.github/ansible/playbook-ci.yml
+++ b/.github/ansible/playbook-ci.yml
@@ -13,28 +13,6 @@
       pgid: "{{ user_gid }}"
 
   roles:
-    - role: "artyorsh.selfhosted.authelia"
-      vars:
-        domain: "example.com"
-        authelia_users:
-          users:
-            admin:
-              displayname: "Admin"
-              email: "admin@{{ domain }}"
-              # supersecret, salt=supersecret
-              password: "$argon2id$v=19$m=1024,t=1,p=8$c3VwZXJzZWNyZXQ$3DK6bsCIIa3MWorb4zatsQ"
-              groups: ["admins"]
-
-        authelia_config:
-          access_control:
-            default_policy: "one_factor"
-            rules: [{ domain: "auth.{{ domain }}", policy: "bypass" }]
-
-        storage:
-          encryption_key: "supersecret"
-
-      tags: ["authelia"]
-
     - role: "artyorsh.selfhosted.duplicati"
       vars:
         duplicati_env:

--- a/.github/ansible/playbook-ci.yml
+++ b/.github/ansible/playbook-ci.yml
@@ -45,9 +45,3 @@
 
     - role: "artyorsh.selfhosted.wallos"
       tags: ["wallos"]
-
-    - role: "artyorsh.selfhosted.wgeasy"
-      vars:
-        wgeasy_docker_settings:
-          network: "docker-ci-network"
-      tags: ["wgeasy"]

--- a/.github/ansible/playbook-ci.yml
+++ b/.github/ansible/playbook-ci.yml
@@ -13,6 +13,15 @@
       pgid: "{{ user_gid }}"
 
   roles:
+    - role: "artyorsh.selfhosted.cloudflare"
+      tags: ["cloudflare"]
+
+    - role: "artyorsh.selfhosted.duplicati"
+      vars:
+        duplicati_env:
+          SETTINGS_ENCRYPTION_KEY: "supersecret"
+      tags: ["duplicati"]
+
     - role: "artyorsh.selfhosted.duplicati"
       vars:
         duplicati_env:

--- a/.github/ansible/playbook-ci.yml
+++ b/.github/ansible/playbook-ci.yml
@@ -13,9 +13,6 @@
       pgid: "{{ user_gid }}"
 
   roles:
-    - role: "artyorsh.selfhosted.changedetection"
-      tags: ["changedetection"]
-
     - role: "artyorsh.selfhosted.duplicati"
       vars:
         duplicati_env:

--- a/.github/ansible/playbook-ci.yml
+++ b/.github/ansible/playbook-ci.yml
@@ -119,11 +119,7 @@
 
     - role: "artyorsh.selfhosted.paperlessngx"
       vars:
-        paperlessngx_docker_settings:
-          network: "docker-ci-bridge-network"
-          puid: "{{ docker_settings.puid }}"
-          pgid: "{{ docker_settings.pgid }}"
-          healthcheck: "{{ docker_settings.healthcheck }}"
+        paperlessngx_docker_settings: "{{ docker_settings }}"
       tags: ["paperlessngx"]
 
     - role: "artyorsh.selfhosted.rss"

--- a/.github/ansible/playbook-ci.yml
+++ b/.github/ansible/playbook-ci.yml
@@ -28,6 +28,9 @@
     - role: "artyorsh.selfhosted.glances"
       tags: ["glances"]
 
+    - role: "artyorsh.selfhosted.homarr"
+      tags: ["homarr"]
+
     - role: "artyorsh.selfhosted.nginx"
       vars:
         nginx_docker_settings:

--- a/.github/ansible/playbook-ci.yml
+++ b/.github/ansible/playbook-ci.yml
@@ -28,6 +28,9 @@
     - role: "artyorsh.selfhosted.glances"
       tags: ["glances"]
 
+    - role: "artyorsh.selfhosted.nginx"
+      tags: ["nginx"]
+
     - role: "artyorsh.selfhosted.paperless_ai"
       tags: ["paperless_ai"]
 

--- a/.github/ansible/playbook-ci.yml
+++ b/.github/ansible/playbook-ci.yml
@@ -38,6 +38,9 @@
 
       tags: ["authelia"]
 
+    - role: "artyorsh.selfhosted.changedetection"
+      tags: ["changedetection"]
+
     - role: "artyorsh.selfhosted.duplicati"
       vars:
         duplicati_env:

--- a/.github/ansible/playbook-ci.yml
+++ b/.github/ansible/playbook-ci.yml
@@ -8,16 +8,27 @@
         name: "artyorsh.selfhosted.docker"
 
   vars:
+    healthcheck:
+      start_period: 5s
+      interval: 30s
+      timeout: 15s
+      retries: 3
+
     forgejo_docker_settings:
       puid: "{{ user_uid }}"
       pgid: "{{ user_gid }}"
 
   roles:
     - role: "artyorsh.selfhosted.adguardhome"
+      vars:
+        adguardhome_docker_settings:
+          healthcheck: "{{ healthcheck }}"
       tags: ["adguardhome"]
 
     - role: "artyorsh.selfhosted.authelia"
       vars:
+        authelia_docker_settings:
+          healthcheck: "{{ healthcheck }}"
         domain: "example.com"
         authelia_users:
           users:
@@ -39,77 +50,120 @@
       tags: ["authelia"]
 
     - role: "artyorsh.selfhosted.changedetection"
+      vars:
+        changedetection_docker_settings:
+          healthcheck: "{{ healthcheck }}"
       tags: ["changedetection"]
 
     - role: "artyorsh.selfhosted.cloudflare"
       vars:
+        cloudflare_docker_settings:
+          healthcheck: "{{ healthcheck }}"
         cloudflare_tunnel_uuid_or_name: "test-tunnel-name"
       tags: ["cloudflare"]
 
     - role: "artyorsh.selfhosted.duplicati"
       vars:
+        duplicati_docker_settings:
+          healthcheck: "{{ healthcheck }}"
         duplicati_env:
           SETTINGS_ENCRYPTION_KEY: "supersecret"
       tags: ["duplicati"]
 
     - role: "artyorsh.selfhosted.duplicati"
       vars:
+        filebrowser_docker_settings:
+          healthcheck: "{{ healthcheck }}"
         duplicati_env:
           SETTINGS_ENCRYPTION_KEY: "supersecret"
       tags: ["duplicati"]
 
     - role: "artyorsh.selfhosted.filebrowser"
+      vars:
+        filebrowser_docker_settings:
+          healthcheck: "{{ healthcheck }}"
       tags: ["filebrowser"]
 
     - role: "artyorsh.selfhosted.forgejo"
+      vars:
+        forgejo_docker_settings:
+          healthcheck: "{{ healthcheck }}"
       tags: ["forgejo"]
 
     - role: "artyorsh.selfhosted.glances"
+      vars:
+        glances_docker_settings:
+          healthcheck: "{{ healthcheck }}"
       tags: ["glances"]
 
     - role: "artyorsh.selfhosted.homarr"
+      vars:
+        homarr_docker_settings:
+          healthcheck: "{{ healthcheck }}"
       tags: ["homarr"]
 
     - role: "artyorsh.selfhosted.homebox"
+      vars:
+        homebox_docker_settings:
+          healthcheck: "{{ healthcheck }}"
       tags: ["homebox"]
 
     - role: "artyorsh.selfhosted.nginx"
       vars:
         nginx_docker_settings:
+          healthcheck: "{{ healthcheck }}"
           network: "docker-ci-network"
           puid: "{{ user_uid }}"
           pgid: "{{ user_gid }}"
       tags: ["nginx"]
 
     - role: "artyorsh.selfhosted.olivetin"
+      vars:
+        olivetin_docker_settings:
+          healthcheck: "{{ healthcheck }}"
       tags: ["olivetin"]
 
     - role: "artyorsh.selfhosted.paperless_ai"
+      vars:
+        paperless_ai_docker_settings:
+          healthcheck: "{{ healthcheck }}"
       tags: ["paperless_ai"]
 
     - role: "artyorsh.selfhosted.paperlessngx"
       vars:
         paperlessngx_docker_settings:
+          healthcheck: "{{ healthcheck }}"
           network: "docker-ci-network"
       tags: ["paperlessngx"]
 
     - role: "artyorsh.selfhosted.rss"
       vars:
         rss_docker_settings:
+          healthcheck: "{{ healthcheck }}"
           network: "docker-ci-network"
       tags: ["rss"]
 
     - role: "artyorsh.selfhosted.vaultwarden"
+      vars:
+        vaultwarden_docker_settings:
+          healthcheck: "{{ healthcheck }}"
       tags: ["vaultwarden"]
 
     - role: "artyorsh.selfhosted.wallos"
+      vars:
+        wallos_docker_settings:
+          healthcheck: "{{ healthcheck }}"
       tags: ["wallos"]
 
     - role: "artyorsh.selfhosted.watchtower"
+      vars:
+        watchtower_docker_settings:
+          healthcheck: "{{ healthcheck }}"
       tags: ["watchtower"]
 
     - role: "artyorsh.selfhosted.wgeasy"
       vars:
         wgeasy_docker_settings:
+          healthcheck: "{{ healthcheck }}"
           network: "docker-ci-network"
       tags: ["wgeasy"]

--- a/.github/ansible/playbook-ci.yml
+++ b/.github/ansible/playbook-ci.yml
@@ -27,3 +27,6 @@
 
     - role: "artyorsh.selfhosted.paperless_ai"
       tags: ["paperless_ai"]
+
+    - role: "artyorsh.selfhosted.paperlessngx"
+      tags: ["paperlessngx"]

--- a/.github/ansible/playbook-ci.yml
+++ b/.github/ansible/playbook-ci.yml
@@ -35,4 +35,7 @@
       tags: ["paperlessngx"]
 
     - role: "artyorsh.selfhosted.rss"
+      vars:
+        rss_docker_settings:
+          network: "docker-ci-network"
       tags: ["rss"]

--- a/.github/ansible/playbook-ci.yml
+++ b/.github/ansible/playbook-ci.yml
@@ -107,3 +107,9 @@
 
     - role: "artyorsh.selfhosted.watchtower"
       tags: ["watchtower"]
+
+    - role: "artyorsh.selfhosted.wgeasy"
+      vars:
+        wgeasy_docker_settings:
+          network: "docker-ci-network"
+      tags: ["wgeasy"]

--- a/.github/ansible/playbook-ci.yml
+++ b/.github/ansible/playbook-ci.yml
@@ -104,3 +104,6 @@
 
     - role: "artyorsh.selfhosted.wallos"
       tags: ["wallos"]
+
+    - role: "artyorsh.selfhosted.watchtower"
+      tags: ["watchtower"]

--- a/.github/ansible/playbook-ci.yml
+++ b/.github/ansible/playbook-ci.yml
@@ -24,3 +24,6 @@
 
     - role: "artyorsh.selfhosted.forgejo"
       tags: ["forgejo"]
+
+    - role: "artyorsh.selfhosted.paperless_ai"
+      tags: ["paperless_ai"]

--- a/.github/ansible/playbook-ci.yml
+++ b/.github/ansible/playbook-ci.yml
@@ -45,3 +45,6 @@
 
     - role: "artyorsh.selfhosted.wallos"
       tags: ["wallos"]
+
+    - role: "artyorsh.selfhosted.watchtower"
+      tags: ["watchtower"]

--- a/.github/ansible/playbook-ci.yml
+++ b/.github/ansible/playbook-ci.yml
@@ -13,6 +13,9 @@
       pgid: "{{ user_gid }}"
 
   roles:
+    - role: "artyorsh.selfhosted.changedetection"
+      tags: ["changedetection"]
+
     - role: "artyorsh.selfhosted.duplicati"
       vars:
         duplicati_env:

--- a/.github/ansible/playbook-ci.yml
+++ b/.github/ansible/playbook-ci.yml
@@ -39,3 +39,6 @@
         rss_docker_settings:
           network: "docker-ci-network"
       tags: ["rss"]
+
+    - role: "artyorsh.selfhosted.vaultwarden"
+      tags: ["vaultwarden"]

--- a/.github/ansible/playbook-ci.yml
+++ b/.github/ansible/playbook-ci.yml
@@ -42,3 +42,6 @@
 
     - role: "artyorsh.selfhosted.vaultwarden"
       tags: ["vaultwarden"]
+
+    - role: "artyorsh.selfhosted.wallos"
+      tags: ["wallos"]

--- a/.github/ansible/playbook-ci.yml
+++ b/.github/ansible/playbook-ci.yml
@@ -24,6 +24,3 @@
 
     - role: "artyorsh.selfhosted.forgejo"
       tags: ["forgejo"]
-
-    - role: "artyorsh.selfhosted.homebox"
-      tags: ["homebox"]

--- a/.github/ansible/playbook-ci.yml
+++ b/.github/ansible/playbook-ci.yml
@@ -14,10 +14,6 @@
       timeout: 15s
       retries: 3
 
-    forgejo_docker_settings:
-      puid: "{{ user_uid }}"
-      pgid: "{{ user_gid }}"
-
   roles:
     - role: "artyorsh.selfhosted.adguardhome"
       vars:
@@ -88,6 +84,8 @@
       vars:
         forgejo_docker_settings:
           healthcheck: "{{ healthcheck }}"
+          puid: "{{ user_uid }}"
+          pgid: "{{ user_gid }}"
       tags: ["forgejo"]
 
     - role: "artyorsh.selfhosted.glances"

--- a/.github/ansible/playbook-ci.yml
+++ b/.github/ansible/playbook-ci.yml
@@ -8,23 +8,25 @@
         name: "artyorsh.selfhosted.docker"
 
   vars:
-    healthcheck:
-      start_period: 5s
-      interval: 30s
-      timeout: 15s
-      retries: 3
+    docker_settings:
+      network: "docker-ci-network"
+      puid: "{{ user_uid }}"
+      pgid: "{{ user_gid }}"
+      healthcheck:
+        start_period: 5s
+        interval: 30s
+        timeout: 15s
+        retries: 3
 
   roles:
     - role: "artyorsh.selfhosted.adguardhome"
       vars:
-        adguardhome_docker_settings:
-          healthcheck: "{{ healthcheck }}"
+        adguardhome_docker_settings: "{{ docker_settings }}"
       tags: ["adguardhome"]
 
     - role: "artyorsh.selfhosted.authelia"
       vars:
-        authelia_docker_settings:
-          healthcheck: "{{ healthcheck }}"
+        authelia_docker_settings: "{{ docker_settings }}"
         domain: "example.com"
         authelia_users:
           users:
@@ -47,121 +49,97 @@
 
     - role: "artyorsh.selfhosted.changedetection"
       vars:
-        changedetection_docker_settings:
-          healthcheck: "{{ healthcheck }}"
+        changedetection_docker_settings: "{{ docker_settings }}"
       tags: ["changedetection"]
 
     - role: "artyorsh.selfhosted.cloudflare"
       vars:
-        cloudflare_docker_settings:
-          healthcheck: "{{ healthcheck }}"
+        cloudflare_docker_settings: "{{ docker_settings }}"
         cloudflare_tunnel_uuid_or_name: "test-tunnel-name"
       tags: ["cloudflare"]
 
     - role: "artyorsh.selfhosted.duplicati"
       vars:
-        duplicati_docker_settings:
-          healthcheck: "{{ healthcheck }}"
+        duplicati_docker_settings: "{{ docker_settings }}"
         duplicati_env:
           SETTINGS_ENCRYPTION_KEY: "supersecret"
       tags: ["duplicati"]
 
     - role: "artyorsh.selfhosted.duplicati"
       vars:
-        filebrowser_docker_settings:
-          healthcheck: "{{ healthcheck }}"
+        filebrowser_docker_settings: "{{ docker_settings }}"
         duplicati_env:
           SETTINGS_ENCRYPTION_KEY: "supersecret"
       tags: ["duplicati"]
 
     - role: "artyorsh.selfhosted.filebrowser"
       vars:
-        filebrowser_docker_settings:
-          healthcheck: "{{ healthcheck }}"
+        filebrowser_docker_settings: "{{ docker_settings }}"
       tags: ["filebrowser"]
 
     - role: "artyorsh.selfhosted.forgejo"
       vars:
-        forgejo_docker_settings:
-          healthcheck: "{{ healthcheck }}"
-          puid: "{{ user_uid }}"
-          pgid: "{{ user_gid }}"
+        forgejo_docker_settings: "{{ docker_settings }}"
       tags: ["forgejo"]
 
     - role: "artyorsh.selfhosted.glances"
       vars:
         glances_docker_settings:
-          healthcheck: "{{ healthcheck }}"
+          healthcheck: "{{ docker_settings.healthcheck }}"
       tags: ["glances"]
 
     - role: "artyorsh.selfhosted.homarr"
       vars:
-        homarr_docker_settings:
-          healthcheck: "{{ healthcheck }}"
+        homarr_docker_settings: "{{ docker_settings }}"
       tags: ["homarr"]
 
     - role: "artyorsh.selfhosted.homebox"
       vars:
-        homebox_docker_settings:
-          healthcheck: "{{ healthcheck }}"
+        homebox_docker_settings: "{{ docker_settings }}"
       tags: ["homebox"]
 
     - role: "artyorsh.selfhosted.nginx"
       vars:
-        nginx_docker_settings:
-          healthcheck: "{{ healthcheck }}"
-          network: "docker-ci-network"
-          puid: "{{ user_uid }}"
-          pgid: "{{ user_gid }}"
+        nginx_docker_settings: "{{ docker_settings }}"
       tags: ["nginx"]
 
     - role: "artyorsh.selfhosted.olivetin"
       vars:
         olivetin_docker_settings:
-          healthcheck: "{{ healthcheck }}"
+          healthcheck: "{{ docker_settings.healthcheck }}"
       tags: ["olivetin"]
 
     - role: "artyorsh.selfhosted.paperless_ai"
       vars:
-        paperless_ai_docker_settings:
-          healthcheck: "{{ healthcheck }}"
+        paperless_ai_docker_settings: "{{ docker_settings }}"
       tags: ["paperless_ai"]
 
     - role: "artyorsh.selfhosted.paperlessngx"
       vars:
-        paperlessngx_docker_settings:
-          healthcheck: "{{ healthcheck }}"
-          network: "docker-ci-network"
+        paperlessngx_docker_settings: "{{ docker_settings }}"
       tags: ["paperlessngx"]
 
     - role: "artyorsh.selfhosted.rss"
       vars:
-        rss_docker_settings:
-          healthcheck: "{{ healthcheck }}"
-          network: "docker-ci-network"
+        rss_docker_settings: "{{ docker_settings }}"
       tags: ["rss"]
 
     - role: "artyorsh.selfhosted.vaultwarden"
       vars:
-        vaultwarden_docker_settings:
-          healthcheck: "{{ healthcheck }}"
+        vaultwarden_docker_settings: "{{ docker_settings }}"
       tags: ["vaultwarden"]
 
     - role: "artyorsh.selfhosted.wallos"
       vars:
-        wallos_docker_settings:
-          healthcheck: "{{ healthcheck }}"
+        wallos_docker_settings: "{{ docker_settings }}"
       tags: ["wallos"]
 
     - role: "artyorsh.selfhosted.watchtower"
       vars:
-        watchtower_docker_settings:
-          healthcheck: "{{ healthcheck }}"
+        watchtower_docker_settings: "{{ docker_settings }}"
       tags: ["watchtower"]
 
     - role: "artyorsh.selfhosted.wgeasy"
       vars:
-        wgeasy_docker_settings:
-          healthcheck: "{{ healthcheck }}"
-          network: "docker-ci-network"
+        wgeasy_docker_settings: "{{ docker_settings }}"
       tags: ["wgeasy"]

--- a/.github/ansible/playbook-ci.yml
+++ b/.github/ansible/playbook-ci.yml
@@ -21,7 +21,10 @@
   roles:
     - role: "artyorsh.selfhosted.adguardhome"
       vars:
-        adguardhome_docker_settings: "{{ docker_settings }}"
+        adguardhome_docker_settings:
+          puid: "{{ docker_settings.puid }}"
+          pgid: "{{ docker_settings.pgid }}"
+          healthcheck: "{{ docker_settings.healthcheck }}"
       tags: ["adguardhome"]
 
     - role: "artyorsh.selfhosted.authelia"

--- a/.github/ansible/playbook-ci.yml
+++ b/.github/ansible/playbook-ci.yml
@@ -119,7 +119,11 @@
 
     - role: "artyorsh.selfhosted.paperlessngx"
       vars:
-        paperlessngx_docker_settings: "{{ docker_settings }}"
+        paperlessngx_docker_settings:
+          network: "docker-ci-bridge-network"
+          puid: "{{ docker_settings.puid }}"
+          pgid: "{{ docker_settings.pgid }}"
+          healthcheck: "{{ docker_settings.healthcheck }}"
       tags: ["paperlessngx"]
 
     - role: "artyorsh.selfhosted.rss"

--- a/.github/ansible/playbook-ci.yml
+++ b/.github/ansible/playbook-ci.yml
@@ -14,6 +14,8 @@
 
   roles:
     - role: "artyorsh.selfhosted.cloudflare"
+      vars:
+        cloudflare_tunnel_uuid_or_name: "test-tunnel-name"
       tags: ["cloudflare"]
 
     - role: "artyorsh.selfhosted.duplicati"

--- a/.github/ansible/playbook-ci.yml
+++ b/.github/ansible/playbook-ci.yml
@@ -45,6 +45,3 @@
 
     - role: "artyorsh.selfhosted.wallos"
       tags: ["wallos"]
-
-    - role: "artyorsh.selfhosted.watchtower"
-      tags: ["watchtower"]

--- a/.github/ansible/playbook-ci.yml
+++ b/.github/ansible/playbook-ci.yml
@@ -45,3 +45,6 @@
 
     - role: "artyorsh.selfhosted.wallos"
       tags: ["wallos"]
+
+    - role: "artyorsh.selfhosted.wgeasy"
+      tags: ["wgeasy"]

--- a/.github/ansible/playbook-ci.yml
+++ b/.github/ansible/playbook-ci.yml
@@ -144,9 +144,5 @@
 
     - role: "artyorsh.selfhosted.wgeasy"
       vars:
-        wgeasy_docker_settings:
-          network: "docker-ci-bridge-network"
-          puid: "{{ docker_settings.puid }}"
-          pgid: "{{ docker_settings.pgid }}"
-          healthcheck: "{{ docker_settings.healthcheck }}"
+        wgeasy_docker_settings: "{{ docker_settings }}"
       tags: ["wgeasy"]

--- a/.github/ansible/playbook-ci.yml
+++ b/.github/ansible/playbook-ci.yml
@@ -16,6 +16,28 @@
     - role: "artyorsh.selfhosted.adguardhome"
       tags: ["adguardhome"]
 
+    - role: "artyorsh.selfhosted.authelia"
+      vars:
+        domain: "example.com"
+        authelia_users:
+          users:
+            admin:
+              displayname: "Admin"
+              email: "admin@{{ domain }}"
+              # supersecret, salt=supersecret
+              password: "$argon2id$v=19$m=1024,t=1,p=8$c3VwZXJzZWNyZXQ$3DK6bsCIIa3MWorb4zatsQ"
+              groups: ["admins"]
+
+        authelia_config:
+          access_control:
+            default_policy: "one_factor"
+            rules: [{ domain: "auth.{{ domain }}", policy: "bypass" }]
+
+        storage:
+          encryption_key: "supersecret"
+
+      tags: ["authelia"]
+
     - role: "artyorsh.selfhosted.duplicati"
       vars:
         duplicati_env:

--- a/.github/ansible/playbook-ci.yml
+++ b/.github/ansible/playbook-ci.yml
@@ -29,6 +29,10 @@
       tags: ["glances"]
 
     - role: "artyorsh.selfhosted.nginx"
+      vars:
+        nginx_docker_settings:
+          puid: "{{ user_uid }}"
+          pgid: "{{ user_gid }}"
       tags: ["nginx"]
 
     - role: "artyorsh.selfhosted.paperless_ai"

--- a/.github/ansible/playbook-ci.yml
+++ b/.github/ansible/playbook-ci.yml
@@ -33,3 +33,6 @@
         paperlessngx_docker_settings:
           network: "docker-ci-network"
       tags: ["paperlessngx"]
+
+    - role: "artyorsh.selfhosted.rss"
+      tags: ["rss"]

--- a/.github/ansible/playbook-ci.yml
+++ b/.github/ansible/playbook-ci.yml
@@ -31,6 +31,7 @@
     - role: "artyorsh.selfhosted.nginx"
       vars:
         nginx_docker_settings:
+          network: "docker-ci-network"
           puid: "{{ user_uid }}"
           pgid: "{{ user_gid }}"
       tags: ["nginx"]

--- a/.github/ansible/playbook-ci.yml
+++ b/.github/ansible/playbook-ci.yml
@@ -25,6 +25,9 @@
     - role: "artyorsh.selfhosted.forgejo"
       tags: ["forgejo"]
 
+    - role: "artyorsh.selfhosted.glances"
+      tags: ["glances"]
+
     - role: "artyorsh.selfhosted.paperless_ai"
       tags: ["paperless_ai"]
 

--- a/.github/ansible/playbook-ci.yml
+++ b/.github/ansible/playbook-ci.yml
@@ -13,6 +13,25 @@
       pgid: "{{ user_gid }}"
 
   roles:
+    - role: "artyorsh.selfhosted.authelia"
+      vars:
+        domain: "example.com"
+        authelia_users:
+          users:
+            admin:
+              displayname: "Admin"
+              email: "admin@{{ domain }}"
+              password: "$argon2id$v=19$m=1024,t=1,p=supersecret"
+              groups: ["admins"]
+
+        authelia_config:
+          rules: [{ domain: "auth.{{ domain }}", policy: "bypass" }]
+
+        storage:
+          encryption_key: "supersecret"
+
+      tags: ["authelia"]
+
     - role: "artyorsh.selfhosted.duplicati"
       vars:
         duplicati_env:

--- a/.github/ansible/playbook-ci.yml
+++ b/.github/ansible/playbook-ci.yml
@@ -47,4 +47,7 @@
       tags: ["wallos"]
 
     - role: "artyorsh.selfhosted.wgeasy"
+      vars:
+        wgeasy_docker_settings:
+          network: "docker-ci-network"
       tags: ["wgeasy"]

--- a/.github/ansible/playbook-ci.yml
+++ b/.github/ansible/playbook-ci.yml
@@ -144,5 +144,9 @@
 
     - role: "artyorsh.selfhosted.wgeasy"
       vars:
-        wgeasy_docker_settings: "{{ docker_settings }}"
+        wgeasy_docker_settings:
+          network: "docker-ci-bridge-network"
+          puid: "{{ docker_settings.puid }}"
+          pgid: "{{ docker_settings.pgid }}"
+          healthcheck: "{{ docker_settings.healthcheck }}"
       tags: ["wgeasy"]

--- a/.github/ansible/playbook-ci.yml
+++ b/.github/ansible/playbook-ci.yml
@@ -25,7 +25,9 @@
               groups: ["admins"]
 
         authelia_config:
-          rules: [{ domain: "auth.{{ domain }}", policy: "bypass" }]
+          access_control:
+            default_policy: "one_factor"
+            rules: [{ domain: "auth.{{ domain }}", policy: "bypass" }]
 
         storage:
           encryption_key: "supersecret"

--- a/.github/workflows/test-ubuntu-lts.yml
+++ b/.github/workflows/test-ubuntu-lts.yml
@@ -27,6 +27,7 @@ jobs:
           - "duplicati"
           - "filebrowser"
           - "forgejo"
+          - "paperless_ai"
 
     steps:
       - uses: "actions/checkout@v4"

--- a/.github/workflows/test-ubuntu-lts.yml
+++ b/.github/workflows/test-ubuntu-lts.yml
@@ -24,6 +24,7 @@ jobs:
     strategy:
       matrix:
         role:
+          - { name: "cloudflare", container_name: "cloudflare" }
           - { name: "duplicati", container_name: "duplicati" }
           - { name: "filebrowser", container_name: "filebrowser" }
           - { name: "forgejo", container_name: "forgejo" }

--- a/.github/workflows/test-ubuntu-lts.yml
+++ b/.github/workflows/test-ubuntu-lts.yml
@@ -4,13 +4,13 @@ name: "Test (Ubuntu 22.04)"
 on:
   pull_request:
     branches:
-      - "staging"
+      - "master"
     paths-ignore:
       - "**.md"
 
   push:
     branches:
-      - "staging"
+      - "master"
     paths-ignore:
       - "**.md"
 

--- a/.github/workflows/test-ubuntu-lts.yml
+++ b/.github/workflows/test-ubuntu-lts.yml
@@ -25,6 +25,7 @@ jobs:
       fail-fast: false
       matrix:
         role:
+          - { name: "adguardhome", container_name: "adguardhome" }
           - { name: "duplicati", container_name: "duplicati" }
           - { name: "filebrowser", container_name: "filebrowser" }
           - { name: "forgejo", container_name: "forgejo" }

--- a/.github/workflows/test-ubuntu-lts.yml
+++ b/.github/workflows/test-ubuntu-lts.yml
@@ -22,6 +22,7 @@ jobs:
     runs-on: "ubuntu-22.04"
 
     strategy:
+      fail-fast: false
       matrix:
         role:
           - { name: "duplicati", container_name: "duplicati" }

--- a/.github/workflows/test-ubuntu-lts.yml
+++ b/.github/workflows/test-ubuntu-lts.yml
@@ -32,6 +32,7 @@ jobs:
           # - { name: "rss", container_name: "miniflux" }
           - { name: "vaultwarden", container_name: "vaultwarden" }
           - { name: "wallos", container_name: "wallos" }
+          - { name: "watchtower", container_name: "watchtower" }
 
     steps:
       - uses: "actions/checkout@v4"

--- a/.github/workflows/test-ubuntu-lts.yml
+++ b/.github/workflows/test-ubuntu-lts.yml
@@ -32,7 +32,6 @@ jobs:
           # - { name: "rss", container_name: "miniflux" }
           - { name: "vaultwarden", container_name: "vaultwarden" }
           - { name: "wallos", container_name: "wallos" }
-          - { name: "wgeasy", container_name: "wg-easy" }
 
     steps:
       - uses: "actions/checkout@v4"

--- a/.github/workflows/test-ubuntu-lts.yml
+++ b/.github/workflows/test-ubuntu-lts.yml
@@ -56,7 +56,7 @@ jobs:
           ansible-playbook -i localhost .github/ansible/playbook-ci.yml -v -e "ansible_user=${USER}" -e "user_uid=$(id -u)" -e "user_gid=$(id -g)" --tags ${{ matrix.role.name }}
 
       - name: "Wait for containers to start"
-        run: "sleep 30"
+        run: "sleep 45"
 
       - name: "Print docker logs"
         run: |

--- a/.github/workflows/test-ubuntu-lts.yml
+++ b/.github/workflows/test-ubuntu-lts.yml
@@ -27,6 +27,7 @@ jobs:
         role:
           - { name: "adguardhome", container_name: "adguardhome" }
           - { name: "authelia", container_name: "authelia" }
+          - { name: "changedetection", container_name: "changedetection" }
           - { name: "duplicati", container_name: "duplicati" }
           - { name: "filebrowser", container_name: "filebrowser" }
           - { name: "forgejo", container_name: "forgejo" }

--- a/.github/workflows/test-ubuntu-lts.yml
+++ b/.github/workflows/test-ubuntu-lts.yml
@@ -24,11 +24,11 @@ jobs:
     strategy:
       matrix:
         role:
-          - "duplicati"
-          - "filebrowser"
-          - "forgejo"
-          - "paperless_ai"
-          - "paperlessngx"
+          - { name: "duplicati", container_name: "duplicati" }
+          - { name: "filebrowser", container_name: "filebrowser" }
+          - { name: "forgejo", container_name: "forgejo" }
+          - { name: "paperless_ai", container_name: "paperless-ai" }
+          - { name: "paperlessngx", container_name: "paperlessngx" }
 
     steps:
       - uses: "actions/checkout@v4"
@@ -52,7 +52,7 @@ jobs:
 
       - name: "Run playbook with role tag"
         run: |
-          ansible-playbook -i localhost .github/ansible/playbook-ci.yml -v -e "ansible_user=${USER}" -e "user_uid=$(id -u)" -e "user_gid=$(id -g)" --tags ${{ matrix.role }}
+          ansible-playbook -i localhost .github/ansible/playbook-ci.yml -v -e "ansible_user=${USER}" -e "user_uid=$(id -u)" -e "user_gid=$(id -g)" --tags ${{ matrix.role.name }}
 
       - name: "Wait for containers to start"
         run: "sleep 30"
@@ -60,11 +60,11 @@ jobs:
       - name: "Print docker logs"
         run: |
           docker ps -a
-          docker logs ${{ matrix.role }}
+          docker logs ${{ matrix.role.container_name }}
 
       - name: "Check container health"
         run: |
-          status=$(docker inspect --format='{{.State.Health.Status}}' ${{ matrix.role }})
+          status=$(docker inspect --format='{{.State.Health.Status}}' ${{ matrix.role.container_name }})
           echo "Container health status: $status"
           if [ "$status" != "healthy" ]; then
             echo "Container is not healthy. Failing the action."

--- a/.github/workflows/test-ubuntu-lts.yml
+++ b/.github/workflows/test-ubuntu-lts.yml
@@ -39,7 +39,7 @@ jobs:
           - { name: "olivetin", container_name: "olivetin" }
           - { name: "paperless_ai", container_name: "paperless-ai" }
           - { name: "paperlessngx", container_name: "paperlessngx" }
-          # - { name: "rss", container_name: "miniflux" }
+          - { name: "rss", container_name: "miniflux" }
           - { name: "vaultwarden", container_name: "vaultwarden" }
           - { name: "wallos", container_name: "wallos" }
 

--- a/.github/workflows/test-ubuntu-lts.yml
+++ b/.github/workflows/test-ubuntu-lts.yml
@@ -70,7 +70,7 @@ jobs:
           ansible-playbook -i localhost .github/ansible/playbook-ci.yml -v -e "ansible_user=${USER}" -e "user_uid=$(id -u)" -e "user_gid=$(id -g)" --tags ${{ matrix.role.name }}
 
       - name: "Wait for containers to start"
-        run: "sleep 30"
+        run: "sleep 60"
 
       - name: "Print docker logs"
         run: |

--- a/.github/workflows/test-ubuntu-lts.yml
+++ b/.github/workflows/test-ubuntu-lts.yml
@@ -42,6 +42,7 @@ jobs:
           - { name: "rss", container_name: "miniflux" }
           - { name: "vaultwarden", container_name: "vaultwarden" }
           - { name: "wallos", container_name: "wallos" }
+          - { name: "watchtower", container_name: "watchtower" }
 
     steps:
       - uses: "actions/checkout@v4"

--- a/.github/workflows/test-ubuntu-lts.yml
+++ b/.github/workflows/test-ubuntu-lts.yml
@@ -29,7 +29,7 @@ jobs:
           - { name: "forgejo", container_name: "forgejo" }
           - { name: "paperless_ai", container_name: "paperless-ai" }
           - { name: "paperlessngx", container_name: "paperlessngx" }
-          - { name: "rss", container_name: "miniflux" }
+          # - { name: "rss", container_name: "miniflux" }
 
     steps:
       - uses: "actions/checkout@v4"

--- a/.github/workflows/test-ubuntu-lts.yml
+++ b/.github/workflows/test-ubuntu-lts.yml
@@ -26,6 +26,7 @@ jobs:
       matrix:
         role:
           - { name: "adguardhome", container_name: "adguardhome" }
+          - { name: "authelia", container_name: "authelia" }
           - { name: "duplicati", container_name: "duplicati" }
           - { name: "filebrowser", container_name: "filebrowser" }
           - { name: "forgejo", container_name: "forgejo" }

--- a/.github/workflows/test-ubuntu-lts.yml
+++ b/.github/workflows/test-ubuntu-lts.yml
@@ -24,7 +24,6 @@ jobs:
     strategy:
       matrix:
         role:
-          - { name: "cloudflare", container_name: "cloudflare" }
           - { name: "duplicati", container_name: "duplicati" }
           - { name: "filebrowser", container_name: "filebrowser" }
           - { name: "forgejo", container_name: "forgejo" }

--- a/.github/workflows/test-ubuntu-lts.yml
+++ b/.github/workflows/test-ubuntu-lts.yml
@@ -30,6 +30,7 @@ jobs:
           - { name: "paperless_ai", container_name: "paperless-ai" }
           - { name: "paperlessngx", container_name: "paperlessngx" }
           # - { name: "rss", container_name: "miniflux" }
+          - { name: "vaultwarden", container_name: "vaultwarden" }
 
     steps:
       - uses: "actions/checkout@v4"

--- a/.github/workflows/test-ubuntu-lts.yml
+++ b/.github/workflows/test-ubuntu-lts.yml
@@ -32,6 +32,7 @@ jobs:
           # - { name: "rss", container_name: "miniflux" }
           - { name: "vaultwarden", container_name: "vaultwarden" }
           - { name: "wallos", container_name: "wallos" }
+          - { name: "wgeasy", container_name: "wg-easy" }
 
     steps:
       - uses: "actions/checkout@v4"

--- a/.github/workflows/test-ubuntu-lts.yml
+++ b/.github/workflows/test-ubuntu-lts.yml
@@ -27,7 +27,7 @@ jobs:
           - "duplicati"
           - "filebrowser"
           - "forgejo"
-          - "homebox"
+
     steps:
       - uses: "actions/checkout@v4"
 

--- a/.github/workflows/test-ubuntu-lts.yml
+++ b/.github/workflows/test-ubuntu-lts.yml
@@ -24,6 +24,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        network:
+          - "host"
+          - "docker-ci-bridge-network"
         role:
           - { name: "adguardhome", container_name: "adguardhome" }
           - { name: "authelia", container_name: "authelia" }
@@ -67,7 +70,7 @@ jobs:
 
       - name: "Run playbook with role tag"
         run: |
-          ansible-playbook -i localhost .github/ansible/playbook-ci.yml -v -e "ansible_user=${USER}" -e "user_uid=$(id -u)" -e "user_gid=$(id -g)" --tags ${{ matrix.role.name }}
+          ansible-playbook -i localhost .github/ansible/playbook-ci.yml -v -e "ansible_user=${USER}" -e "network=${{ matrix.network }}" -e "puid=$(id -u)" -e "pgid=$(id -g)" --tags ${{ matrix.role.name }}
 
       - name: "Wait for containers to start"
         run: "sleep 120"

--- a/.github/workflows/test-ubuntu-lts.yml
+++ b/.github/workflows/test-ubuntu-lts.yml
@@ -24,6 +24,7 @@ jobs:
     strategy:
       matrix:
         role:
+          - { name: "authelia", container_name: "authelia" }
           - { name: "duplicati", container_name: "duplicati" }
           - { name: "filebrowser", container_name: "filebrowser" }
           - { name: "forgejo", container_name: "forgejo" }

--- a/.github/workflows/test-ubuntu-lts.yml
+++ b/.github/workflows/test-ubuntu-lts.yml
@@ -70,7 +70,7 @@ jobs:
           ansible-playbook -i localhost .github/ansible/playbook-ci.yml -v -e "ansible_user=${USER}" -e "user_uid=$(id -u)" -e "user_gid=$(id -g)" --tags ${{ matrix.role.name }}
 
       - name: "Wait for containers to start"
-        run: "sleep 60"
+        run: "sleep 300"
 
       - name: "Print docker logs"
         run: |

--- a/.github/workflows/test-ubuntu-lts.yml
+++ b/.github/workflows/test-ubuntu-lts.yml
@@ -28,6 +28,7 @@ jobs:
           - "filebrowser"
           - "forgejo"
           - "paperless_ai"
+          - "paperlessngx"
 
     steps:
       - uses: "actions/checkout@v4"

--- a/.github/workflows/test-ubuntu-lts.yml
+++ b/.github/workflows/test-ubuntu-lts.yml
@@ -24,7 +24,6 @@ jobs:
     strategy:
       matrix:
         role:
-          - { name: "authelia", container_name: "authelia" }
           - { name: "duplicati", container_name: "duplicati" }
           - { name: "filebrowser", container_name: "filebrowser" }
           - { name: "forgejo", container_name: "forgejo" }

--- a/.github/workflows/test-ubuntu-lts.yml
+++ b/.github/workflows/test-ubuntu-lts.yml
@@ -28,6 +28,7 @@ jobs:
           - { name: "adguardhome", container_name: "adguardhome" }
           - { name: "authelia", container_name: "authelia" }
           - { name: "changedetection", container_name: "changedetection" }
+          - { name: "cloudflare", container_name: "cloudflare" }
           - { name: "duplicati", container_name: "duplicati" }
           - { name: "filebrowser", container_name: "filebrowser" }
           - { name: "forgejo", container_name: "forgejo" }

--- a/.github/workflows/test-ubuntu-lts.yml
+++ b/.github/workflows/test-ubuntu-lts.yml
@@ -24,6 +24,7 @@ jobs:
     strategy:
       matrix:
         role:
+          - { name: "changedetection", container_name: "changedetection" }
           - { name: "duplicati", container_name: "duplicati" }
           - { name: "filebrowser", container_name: "filebrowser" }
           - { name: "forgejo", container_name: "forgejo" }

--- a/.github/workflows/test-ubuntu-lts.yml
+++ b/.github/workflows/test-ubuntu-lts.yml
@@ -70,7 +70,7 @@ jobs:
           ansible-playbook -i localhost .github/ansible/playbook-ci.yml -v -e "ansible_user=${USER}" -e "user_uid=$(id -u)" -e "user_gid=$(id -g)" --tags ${{ matrix.role.name }}
 
       - name: "Wait for containers to start"
-        run: "sleep 300"
+        run: "sleep 120"
 
       - name: "Print docker logs"
         run: |

--- a/.github/workflows/test-ubuntu-lts.yml
+++ b/.github/workflows/test-ubuntu-lts.yml
@@ -32,7 +32,6 @@ jobs:
           # - { name: "rss", container_name: "miniflux" }
           - { name: "vaultwarden", container_name: "vaultwarden" }
           - { name: "wallos", container_name: "wallos" }
-          - { name: "watchtower", container_name: "watchtower" }
 
     steps:
       - uses: "actions/checkout@v4"

--- a/.github/workflows/test-ubuntu-lts.yml
+++ b/.github/workflows/test-ubuntu-lts.yml
@@ -29,6 +29,7 @@ jobs:
           - { name: "forgejo", container_name: "forgejo" }
           - { name: "paperless_ai", container_name: "paperless-ai" }
           - { name: "paperlessngx", container_name: "paperlessngx" }
+          - { name: "rss", container_name: "miniflux" }
 
     steps:
       - uses: "actions/checkout@v4"

--- a/.github/workflows/test-ubuntu-lts.yml
+++ b/.github/workflows/test-ubuntu-lts.yml
@@ -28,6 +28,7 @@ jobs:
           - { name: "filebrowser", container_name: "filebrowser" }
           - { name: "forgejo", container_name: "forgejo" }
           - { name: "glances", container_name: "glances" }
+          - { name: "nginx", container_name: "nginx-proxy-manager" }
           - { name: "paperless_ai", container_name: "paperless-ai" }
           - { name: "paperlessngx", container_name: "paperlessngx" }
           # - { name: "rss", container_name: "miniflux" }

--- a/.github/workflows/test-ubuntu-lts.yml
+++ b/.github/workflows/test-ubuntu-lts.yml
@@ -30,6 +30,7 @@ jobs:
           - { name: "forgejo", container_name: "forgejo" }
           - { name: "glances", container_name: "glances" }
           - { name: "homarr", container_name: "homarr" }
+          - { name: "homebox", container_name: "homebox" }
           - { name: "nginx", container_name: "nginx-proxy-manager" }
           - { name: "olivetin", container_name: "olivetin" }
           - { name: "paperless_ai", container_name: "paperless-ai" }

--- a/.github/workflows/test-ubuntu-lts.yml
+++ b/.github/workflows/test-ubuntu-lts.yml
@@ -27,6 +27,7 @@ jobs:
           - { name: "duplicati", container_name: "duplicati" }
           - { name: "filebrowser", container_name: "filebrowser" }
           - { name: "forgejo", container_name: "forgejo" }
+          - { name: "glances", container_name: "glances" }
           - { name: "paperless_ai", container_name: "paperless-ai" }
           - { name: "paperlessngx", container_name: "paperlessngx" }
           # - { name: "rss", container_name: "miniflux" }

--- a/.github/workflows/test-ubuntu-lts.yml
+++ b/.github/workflows/test-ubuntu-lts.yml
@@ -43,6 +43,7 @@ jobs:
           - { name: "vaultwarden", container_name: "vaultwarden" }
           - { name: "wallos", container_name: "wallos" }
           - { name: "watchtower", container_name: "watchtower" }
+          - { name: "wgeasy", container_name: "wg-easy" }
 
     steps:
       - uses: "actions/checkout@v4"

--- a/.github/workflows/test-ubuntu-lts.yml
+++ b/.github/workflows/test-ubuntu-lts.yml
@@ -28,6 +28,7 @@ jobs:
           - { name: "filebrowser", container_name: "filebrowser" }
           - { name: "forgejo", container_name: "forgejo" }
           - { name: "glances", container_name: "glances" }
+          - { name: "homarr", container_name: "homarr" }
           - { name: "nginx", container_name: "nginx-proxy-manager" }
           - { name: "olivetin", container_name: "olivetin" }
           - { name: "paperless_ai", container_name: "paperless-ai" }

--- a/.github/workflows/test-ubuntu-lts.yml
+++ b/.github/workflows/test-ubuntu-lts.yml
@@ -56,7 +56,7 @@ jobs:
           ansible-playbook -i localhost .github/ansible/playbook-ci.yml -v -e "ansible_user=${USER}" -e "user_uid=$(id -u)" -e "user_gid=$(id -g)" --tags ${{ matrix.role.name }}
 
       - name: "Wait for containers to start"
-        run: "sleep 45"
+        run: "sleep 30"
 
       - name: "Print docker logs"
         run: |

--- a/.github/workflows/test-ubuntu-lts.yml
+++ b/.github/workflows/test-ubuntu-lts.yml
@@ -26,7 +26,7 @@ jobs:
       matrix:
         network:
           - "host"
-          - "docker-ci-bridge-network"
+          # - "docker-ci-bridge-network"
         role:
           - { name: "adguardhome", container_name: "adguardhome" }
           - { name: "authelia", container_name: "authelia" }

--- a/.github/workflows/test-ubuntu-lts.yml
+++ b/.github/workflows/test-ubuntu-lts.yml
@@ -24,6 +24,7 @@ jobs:
     strategy:
       matrix:
         role:
+          - { name: "adguardhome", container_name: "adguardhome" }
           - { name: "duplicati", container_name: "duplicati" }
           - { name: "filebrowser", container_name: "filebrowser" }
           - { name: "forgejo", container_name: "forgejo" }

--- a/.github/workflows/test-ubuntu-lts.yml
+++ b/.github/workflows/test-ubuntu-lts.yml
@@ -29,6 +29,7 @@ jobs:
           - { name: "forgejo", container_name: "forgejo" }
           - { name: "glances", container_name: "glances" }
           - { name: "nginx", container_name: "nginx-proxy-manager" }
+          - { name: "olivetin", container_name: "olivetin" }
           - { name: "paperless_ai", container_name: "paperless-ai" }
           - { name: "paperlessngx", container_name: "paperlessngx" }
           # - { name: "rss", container_name: "miniflux" }

--- a/.github/workflows/test-ubuntu-lts.yml
+++ b/.github/workflows/test-ubuntu-lts.yml
@@ -24,7 +24,6 @@ jobs:
     strategy:
       matrix:
         role:
-          - { name: "adguardhome", container_name: "adguardhome" }
           - { name: "duplicati", container_name: "duplicati" }
           - { name: "filebrowser", container_name: "filebrowser" }
           - { name: "forgejo", container_name: "forgejo" }

--- a/.github/workflows/test-ubuntu-lts.yml
+++ b/.github/workflows/test-ubuntu-lts.yml
@@ -26,7 +26,7 @@ jobs:
       matrix:
         network:
           - "host"
-          # - "docker-ci-bridge-network"
+          - "docker-ci-bridge-network"
         role:
           - { name: "adguardhome", container_name: "adguardhome" }
           - { name: "authelia", container_name: "authelia" }

--- a/.github/workflows/test-ubuntu-lts.yml
+++ b/.github/workflows/test-ubuntu-lts.yml
@@ -70,7 +70,13 @@ jobs:
 
       - name: "Run playbook with role tag"
         run: |
-          ansible-playbook -i localhost .github/ansible/playbook-ci.yml -v -e "ansible_user=${USER}" -e "network=${{ matrix.network }}" -e "puid=$(id -u)" -e "pgid=$(id -g)" --tags ${{ matrix.role.name }}
+          ansible-playbook -i localhost .github/ansible/playbook-ci.yml \
+            --tags ${{ matrix.role.name }} \
+            -e "ansible_user=${USER}" \
+            -e "network=${{ matrix.network }}" \
+            -e "puid=$(id -u)" \
+            -e "pgid=$(id -g)" \
+            -v
 
       - name: "Wait for containers to start"
         run: "sleep 120"

--- a/.github/workflows/test-ubuntu-lts.yml
+++ b/.github/workflows/test-ubuntu-lts.yml
@@ -31,6 +31,7 @@ jobs:
           - { name: "paperlessngx", container_name: "paperlessngx" }
           # - { name: "rss", container_name: "miniflux" }
           - { name: "vaultwarden", container_name: "vaultwarden" }
+          - { name: "wallos", container_name: "wallos" }
 
     steps:
       - uses: "actions/checkout@v4"

--- a/.github/workflows/test-ubuntu-lts.yml
+++ b/.github/workflows/test-ubuntu-lts.yml
@@ -24,7 +24,6 @@ jobs:
     strategy:
       matrix:
         role:
-          - { name: "changedetection", container_name: "changedetection" }
           - { name: "duplicati", container_name: "duplicati" }
           - { name: "filebrowser", container_name: "filebrowser" }
           - { name: "forgejo", container_name: "forgejo" }

--- a/roles/adguardhome/tasks/adguardhome.yml
+++ b/roles/adguardhome/tasks/adguardhome.yml
@@ -28,6 +28,7 @@
     networks:
       - name: "{{ adguardhome_docker_settings.network }}"
     state: "started"
+    healthcheck: "{{ adguardhome_docker_settings.healthcheck }}"
     env: "{{ adguardhome_env_default | combine(adguardhome_env) }}"
     ports:
       - "{{ adguardhome_dns_port }}:53/tcp"

--- a/roles/adguardhome/tasks/adguardhome.yml
+++ b/roles/adguardhome/tasks/adguardhome.yml
@@ -2,7 +2,7 @@
 - name: "Prepare task variables"
   ansible.builtin.set_fact:
     adguardhome_service_id: "adguardhome"
-    adguardhome_docker_settings: "{{ adguardhome_docker_settings_default | combine(adguardhome_docker_settings) }}"
+    adguardhome_docker_settings: "{{ adguardhome_docker_settings_default | combine(adguardhome_docker_settings, recursive=true) }}"
 
 - name: "Make sure config directories exist"
   ansible.builtin.file:

--- a/roles/adguardhome/tasks/adguardhome.yml
+++ b/roles/adguardhome/tasks/adguardhome.yml
@@ -28,7 +28,6 @@
     networks:
       - name: "{{ adguardhome_docker_settings.network }}"
     state: "started"
-    healthcheck: "{{ adguardhome_docker_settings.healthcheck }}"
     env: "{{ adguardhome_env_default | combine(adguardhome_env) }}"
     ports:
       - "{{ adguardhome_dns_port }}:53/tcp"

--- a/roles/adguardhome/vars/main.yml
+++ b/roles/adguardhome/vars/main.yml
@@ -4,11 +4,6 @@ adguardhome_docker_settings_default:
   puid: "1000"
   pgid: "1000"
   tz: "Etc/UTC"
-  healthcheck:
-    test: ["CMD", "nslookup", "adguard.com", "127.0.0.1", ">", "/dev/null"]
-    interval: 5s
-    timeout: 5s
-    retries: 3
 
 adguardhome_env_default:
   TZ: "{{ adguardhome_docker_settings.tz }}"

--- a/roles/adguardhome/vars/main.yml
+++ b/roles/adguardhome/vars/main.yml
@@ -6,9 +6,9 @@ adguardhome_docker_settings_default:
   tz: "Etc/UTC"
   healthcheck:
     test: ["CMD", "nslookup", "adguard.com", "127.0.0.1", ">", "/dev/null"]
-    start_period: 20s
-    interval: 5s
-    timeout: 5s
+    start_period: 10s
+    interval: 30s
+    timeout: 15s
     retries: 3
 
 adguardhome_env_default:

--- a/roles/adguardhome/vars/main.yml
+++ b/roles/adguardhome/vars/main.yml
@@ -5,7 +5,7 @@ adguardhome_docker_settings_default:
   pgid: "1000"
   tz: "Etc/UTC"
   healthcheck:
-    test: ["CMD", "curl", "--fail", "http://localhost:3000"]
+    test: ["CMD", "nslookup", "adguard.com", "127.0.0.1", ">", "/dev/null"]
     interval: 5s
     timeout: 5s
     retries: 3

--- a/roles/adguardhome/vars/main.yml
+++ b/roles/adguardhome/vars/main.yml
@@ -4,6 +4,11 @@ adguardhome_docker_settings_default:
   puid: "1000"
   pgid: "1000"
   tz: "Etc/UTC"
+  healthcheck:
+    test: ["CMD", "curl", "--fail", "http://localhost:3000"]
+    interval: 5s
+    timeout: 5s
+    retries: 3
 
 adguardhome_env_default:
   TZ: "{{ adguardhome_docker_settings.tz }}"

--- a/roles/adguardhome/vars/main.yml
+++ b/roles/adguardhome/vars/main.yml
@@ -6,6 +6,7 @@ adguardhome_docker_settings_default:
   tz: "Etc/UTC"
   healthcheck:
     test: ["CMD", "nslookup", "adguard.com", "127.0.0.1", ">", "/dev/null"]
+    start_period: 20s
     interval: 5s
     timeout: 5s
     retries: 3

--- a/roles/adguardhome/vars/main.yml
+++ b/roles/adguardhome/vars/main.yml
@@ -4,6 +4,11 @@ adguardhome_docker_settings_default:
   puid: "1000"
   pgid: "1000"
   tz: "Etc/UTC"
+  healthcheck:
+    test: ["CMD", "nslookup", "adguard.com", "127.0.0.1", ">", "/dev/null"]
+    interval: 5s
+    timeout: 5s
+    retries: 3
 
 adguardhome_env_default:
   TZ: "{{ adguardhome_docker_settings.tz }}"

--- a/roles/authelia/tasks/main.yml
+++ b/roles/authelia/tasks/main.yml
@@ -43,6 +43,7 @@
     networks:
       - name: "{{ authelia_docker_settings.network }}"
     state: "started"
+    healthcheck: "{{ authelia_docker_settings.healthcheck }}"
     env: "{{ authelia_env_default | combine(authelia_env) }}"
     ports:
       - "{{ authelia_port }}:9091"

--- a/roles/authelia/tasks/main.yml
+++ b/roles/authelia/tasks/main.yml
@@ -2,7 +2,7 @@
 - name: "Prepare task variables"
   ansible.builtin.set_fact:
     authelia_service_id: "authelia"
-    authelia_docker_settings: "{{ authelia_docker_settings_default | combine(authelia_docker_settings) }}"
+    authelia_docker_settings: "{{ authelia_docker_settings_default | combine(authelia_docker_settings, recursive=true) }}"
 
 - name: "Make sure {{ authelia_docker_settings.network }} docker network exists"
   when: authelia_docker_settings.network != "host"

--- a/roles/authelia/vars/main.yml
+++ b/roles/authelia/vars/main.yml
@@ -6,6 +6,7 @@ authelia_docker_settings_default:
   tz: "Etc/UTC"
   healthcheck:
     test: ["CMD", "curl", "--fail", "http://localhost:9091"]
+    start_period: 10s
     interval: 5s
     timeout: 5s
     retries: 3

--- a/roles/authelia/vars/main.yml
+++ b/roles/authelia/vars/main.yml
@@ -4,6 +4,11 @@ authelia_docker_settings_default:
   puid: "1000"
   pgid: "1000"
   tz: "Etc/UTC"
+  healthcheck:
+    test: ["CMD", "curl", "--fail", "http://localhost:9091"]
+    interval: 5s
+    timeout: 5s
+    retries: 3
 
 authelia_env_default:
   TZ: "{{ authelia_docker_settings.tz }}"

--- a/roles/authelia/vars/main.yml
+++ b/roles/authelia/vars/main.yml
@@ -6,9 +6,9 @@ authelia_docker_settings_default:
   tz: "Etc/UTC"
   healthcheck:
     test: ["CMD", "curl", "--fail", "http://localhost:9091"]
-    start_period: 20s
-    interval: 5s
-    timeout: 5s
+    start_period: 10s
+    interval: 30s
+    timeout: 15s
     retries: 3
 
 authelia_env_default:

--- a/roles/authelia/vars/main.yml
+++ b/roles/authelia/vars/main.yml
@@ -6,7 +6,7 @@ authelia_docker_settings_default:
   tz: "Etc/UTC"
   healthcheck:
     test: ["CMD", "curl", "--fail", "http://localhost:9091"]
-    start_period: 10s
+    start_period: 20s
     interval: 5s
     timeout: 5s
     retries: 3

--- a/roles/changedetection/tasks/changedetection.yml
+++ b/roles/changedetection/tasks/changedetection.yml
@@ -1,6 +1,5 @@
 # https://hay-kot.github.io/changedetection/quick-start/#env-variables-configuration
 ---
-
 - name: "Make sure config directories exist"
   ansible.builtin.file:
     path: "{{ item }}"
@@ -18,6 +17,7 @@
     networks:
       - name: "{{ changedetection_docker_settings.network }}"
     state: "started"
+    healthcheck: "{{ changedetection_docker_settings.healthcheck }}"
     env: "{{ changedetection_env_default | combine(changedetection_env) }}"
     ports:
       - "{{ changedetection_webui_port }}:5000"

--- a/roles/changedetection/tasks/changedetection.yml
+++ b/roles/changedetection/tasks/changedetection.yml
@@ -1,5 +1,6 @@
 # https://hay-kot.github.io/changedetection/quick-start/#env-variables-configuration
 ---
+
 - name: "Make sure config directories exist"
   ansible.builtin.file:
     path: "{{ item }}"
@@ -17,7 +18,6 @@
     networks:
       - name: "{{ changedetection_docker_settings.network }}"
     state: "started"
-    healthcheck: "{{ changedetection_docker_settings.healthcheck }}"
     env: "{{ changedetection_env_default | combine(changedetection_env) }}"
     ports:
       - "{{ changedetection_webui_port }}:5000"

--- a/roles/changedetection/tasks/main.yml
+++ b/roles/changedetection/tasks/main.yml
@@ -2,7 +2,7 @@
 - name: "Prepare task variables"
   ansible.builtin.set_fact:
     changedetection_service_id: "changedetection"
-    changedetection_docker_settings: "{{ changedetection_docker_settings_default | combine(changedetection_docker_settings) }}"
+    changedetection_docker_settings: "{{ changedetection_docker_settings_default | combine(changedetection_docker_settings, recursive=true) }}"
 
 - name: "Make sure {{ changedetection_docker_settings.network }} docker network exists"
   when: changedetection_docker_settings.network != "host"

--- a/roles/changedetection/vars/main.yml
+++ b/roles/changedetection/vars/main.yml
@@ -6,6 +6,7 @@ changedetection_docker_settings_default:
   tz: "Etc/UTC"
   healthcheck:
     test: ["CMD", "curl", "--fail", "http://localhost:5000"]
+    start_period: 20s
     interval: 5s
     timeout: 5s
     retries: 3

--- a/roles/changedetection/vars/main.yml
+++ b/roles/changedetection/vars/main.yml
@@ -6,9 +6,9 @@ changedetection_docker_settings_default:
   tz: "Etc/UTC"
   healthcheck:
     test: ["CMD", "curl", "--fail", "http://localhost:5000"]
-    start_period: 20s
-    interval: 5s
-    timeout: 5s
+    start_period: 10s
+    interval: 30s
+    timeout: 15s
     retries: 3
 
 changedetection_env_default:

--- a/roles/changedetection/vars/main.yml
+++ b/roles/changedetection/vars/main.yml
@@ -11,6 +11,7 @@ changedetection_docker_settings_default:
     retries: 3
 
 changedetection_env_default:
+  LC_ALL: "en_US.UTF-8"
   TZ: "{{ changedetection_docker_settings.tz }}"
   PUID: "{{ changedetection_docker_settings.puid }}"
   PGID: "{{ changedetection_docker_settings.pgid }}"

--- a/roles/changedetection/vars/main.yml
+++ b/roles/changedetection/vars/main.yml
@@ -4,6 +4,11 @@ changedetection_docker_settings_default:
   puid: "1000"
   pgid: "1000"
   tz: "Etc/UTC"
+  healthcheck:
+    test: ["CMD", "curl", "--fail", "http://localhost:5000"]
+    interval: 5s
+    timeout: 5s
+    retries: 3
 
 changedetection_env_default:
   TZ: "{{ changedetection_docker_settings.tz }}"

--- a/roles/changedetection/vars/main.yml
+++ b/roles/changedetection/vars/main.yml
@@ -4,11 +4,6 @@ changedetection_docker_settings_default:
   puid: "1000"
   pgid: "1000"
   tz: "Etc/UTC"
-  healthcheck:
-    test: ["CMD", "curl", "--fail", "http://localhost:5000"]
-    interval: 5s
-    timeout: 5s
-    retries: 3
 
 changedetection_env_default:
   TZ: "{{ changedetection_docker_settings.tz }}"

--- a/roles/changedetection/vars/main.yml
+++ b/roles/changedetection/vars/main.yml
@@ -11,7 +11,6 @@ changedetection_docker_settings_default:
     retries: 3
 
 changedetection_env_default:
-  LC_ALL: "en_US.UTF-8"
   TZ: "{{ changedetection_docker_settings.tz }}"
   PUID: "{{ changedetection_docker_settings.puid }}"
   PGID: "{{ changedetection_docker_settings.pgid }}"

--- a/roles/cloudflare/defaults/main.yml
+++ b/roles/cloudflare/defaults/main.yml
@@ -9,5 +9,3 @@ cloudflare_tunnel_ssh_enabled: true
 cloudflare_certificate_public_key: ""
 
 cloudflare_env: {}
-
-cloudflare_docker_settings: {}

--- a/roles/cloudflare/defaults/main.yml
+++ b/roles/cloudflare/defaults/main.yml
@@ -9,3 +9,5 @@ cloudflare_tunnel_ssh_enabled: true
 cloudflare_certificate_public_key: ""
 
 cloudflare_env: {}
+
+cloudflare_docker_settings: {}

--- a/roles/cloudflare/tasks/cloudflared.yml
+++ b/roles/cloudflare/tasks/cloudflared.yml
@@ -3,7 +3,6 @@
   ansible.builtin.set_fact:
     cloudflare_service_id: "cloudflare"
     cloudflare_root_dir: "/opt/docker/cloudflare"
-    cloudflare_docker_settings: "{{ cloudflare_docker_settings_default | combine(cloudflare_docker_settings) }}"
 
 - name: "Prepare task variables"
   ansible.builtin.set_fact:
@@ -16,7 +15,6 @@
     image: "cloudflare/cloudflared:{{ cloudflare_tunnel_version }}"
     networks: "{{ tunnel_networks | default([]) | list }}"
     state: "started"
-    healthcheck: "{{ cloudflare_docker_settings.healthcheck }}"
     env: "{{ cloudflare_env_default | combine(cloudflare_env) }}"
     command: "tunnel --no-autoupdate run {{ cloudflare_tunnel_uuid_or_name }}"
     restart_policy: "unless-stopped"

--- a/roles/cloudflare/tasks/cloudflared.yml
+++ b/roles/cloudflare/tasks/cloudflared.yml
@@ -3,7 +3,7 @@
   ansible.builtin.set_fact:
     cloudflare_service_id: "cloudflare"
     cloudflare_root_dir: "/opt/docker/cloudflare"
-    cloudflare_docker_settings: "{{ cloudflare_docker_settings_default | combine(cloudflare_docker_settings) }}"
+    cloudflare_docker_settings: "{{ cloudflare_docker_settings_default | combine(cloudflare_docker_settings, recursive=true) }}"
 
 - name: "Prepare task variables"
   ansible.builtin.set_fact:

--- a/roles/cloudflare/tasks/cloudflared.yml
+++ b/roles/cloudflare/tasks/cloudflared.yml
@@ -3,6 +3,7 @@
   ansible.builtin.set_fact:
     cloudflare_service_id: "cloudflare"
     cloudflare_root_dir: "/opt/docker/cloudflare"
+    cloudflare_docker_settings: "{{ cloudflare_docker_settings_default | combine(cloudflare_docker_settings) }}"
 
 - name: "Prepare task variables"
   ansible.builtin.set_fact:
@@ -15,6 +16,7 @@
     image: "cloudflare/cloudflared:{{ cloudflare_tunnel_version }}"
     networks: "{{ tunnel_networks | default([]) | list }}"
     state: "started"
+    healthcheck: "{{ cloudflare_docker_settings.healthcheck }}"
     env: "{{ cloudflare_env_default | combine(cloudflare_env) }}"
     command: "tunnel --no-autoupdate run {{ cloudflare_tunnel_uuid_or_name }}"
     restart_policy: "unless-stopped"

--- a/roles/cloudflare/vars/main.yml
+++ b/roles/cloudflare/vars/main.yml
@@ -1,3 +1,10 @@
 ---
+cloudflare_docker_settings_default:
+  healthcheck:
+    test: ["CMD", "cloudflared", "tunnel", "ready"]
+    interval: 5s
+    timeout: 5s
+    retries: 3
+
 cloudflare_env_default:
   TUNNEL_TOKEN: ""

--- a/roles/cloudflare/vars/main.yml
+++ b/roles/cloudflare/vars/main.yml
@@ -1,10 +1,3 @@
 ---
-cloudflare_docker_settings_default:
-  healthcheck:
-    test: ["CMD", "cloudflared", "tunnel", "ready"]
-    interval: 5s
-    timeout: 5s
-    retries: 3
-
 cloudflare_env_default:
   TUNNEL_TOKEN: ""

--- a/roles/duplicati/tasks/main.yml
+++ b/roles/duplicati/tasks/main.yml
@@ -5,7 +5,7 @@
 - name: "Prepare task variables"
   ansible.builtin.set_fact:
     duplicati_service_id: "duplicati"
-    duplicati_docker_settings: "{{ duplicati_docker_settings_default | combine(duplicati_docker_settings) }}"
+    duplicati_docker_settings: "{{ duplicati_docker_settings_default | combine(duplicati_docker_settings, recursive=true) }}"
 
 - name: "Make sure {{ duplicati_docker_settings.network }} docker network exists"
   when: duplicati_docker_settings.network != "host"

--- a/roles/filebrowser/tasks/main.yml
+++ b/roles/filebrowser/tasks/main.yml
@@ -4,7 +4,7 @@
 - name: "Prepare task variables"
   ansible.builtin.set_fact:
     filebrowser_service_id: "filebrowser"
-    filebrowser_docker_settings: "{{ filebrowser_docker_settings_default | combine(filebrowser_docker_settings) }}"
+    filebrowser_docker_settings: "{{ filebrowser_docker_settings_default | combine(filebrowser_docker_settings, recursive=true) }}"
 
 - name: "Make sure config directory exists"
   ansible.builtin.file:

--- a/roles/forgejo/tasks/main.yml
+++ b/roles/forgejo/tasks/main.yml
@@ -2,7 +2,7 @@
 - name: "Combine docker_settings with default docker settings"
   ansible.builtin.set_fact:
     forgejo_service_id: "forgejo"
-    forgejo_docker_settings: "{{ forgejo_docker_settings_default | combine(forgejo_docker_settings) }}"
+    forgejo_docker_settings: "{{ forgejo_docker_settings_default | combine(forgejo_docker_settings, recursive=true) }}"
 
 - name: "Prepare task variables"
   ansible.builtin.set_fact:

--- a/roles/glances/tasks/main.yml
+++ b/roles/glances/tasks/main.yml
@@ -2,7 +2,7 @@
 - name: "Prepare task variables"
   ansible.builtin.set_fact:
     glances_service_id: "glances"
-    glances_docker_settings: "{{ glances_docker_settings_default | combine(glances_docker_settings) }}"
+    glances_docker_settings: "{{ glances_docker_settings_default | combine(glances_docker_settings, recursive=true) }}"
     glances_docker_volumes:
       - "{{ glances_install_dir }}/glances.conf:/etc/glances/glances.conf"
       - "{{ glances_install_dir }}/notify.py:/etc/notify.py"

--- a/roles/glances/tasks/main.yml
+++ b/roles/glances/tasks/main.yml
@@ -52,6 +52,7 @@
     networks:
       - name: "{{ glances_docker_settings.network }}"
     state: "started"
+    healthcheck: "{{ glances_docker_settings.healthcheck }}"
     env: "{{ glances_env_default | combine(glances_env) }}"
     ports:
       - "{{ glances_webui_port }}:61208"

--- a/roles/glances/vars/main.yml
+++ b/roles/glances/vars/main.yml
@@ -4,6 +4,11 @@ glances_docker_settings_default:
   puid: "1000"
   pgid: "1000"
   tz: "Etc/UTC"
+  healthcheck:
+    test: ["CMD", "curl", "--fail", "http://localhost:61208"]
+    interval: 5s
+    timeout: 5s
+    retries: 3
 
 glances_env_default:
   TZ: "{{ glances_docker_settings.tz }}"

--- a/roles/homarr/defaults/main.yml
+++ b/roles/homarr/defaults/main.yml
@@ -4,8 +4,6 @@ homarr_version: "latest"
 homarr_port: 80
 homarr_install_dir: "/opt/docker/homarr"
 
-homarr_docker_settings:
-  network: "host"
-  puid: "1000"
-  pgid: "1000"
-  tz: "Etc/UTC"
+homarr_env: {}
+
+homarr_docker_settings: {}

--- a/roles/homarr/tasks/main.yml
+++ b/roles/homarr/tasks/main.yml
@@ -4,6 +4,7 @@
 - name: "Prepare task variables"
   ansible.builtin.set_fact:
     homarr_service_id: "homarr"
+    homarr_docker_settings: "{{ homarr_docker_settings_default | combine(homarr_docker_settings) }}"
 
 - name: "Make sure config directories exist"
   ansible.builtin.file:
@@ -30,11 +31,8 @@
     networks:
       - name: "{{ homarr_docker_settings.network }}"
     state: "started"
-    env:
-      TZ: "{{ homarr_docker_settings.tz }}"
-      PUID: "{{ homarr_docker_settings.puid }}"
-      PGID: "{{ homarr_docker_settings.pgid }}"
-      DISABLE_ANALYTICS: "true"
+    healthcheck: "{{ homarr_docker_settings.healthcheck }}"
+    env: "{{ homarr_env_default | combine(homarr_env) }}"
     ports:
       - "{{ homarr_port }}:7575"
     volumes:

--- a/roles/homarr/tasks/main.yml
+++ b/roles/homarr/tasks/main.yml
@@ -4,7 +4,7 @@
 - name: "Prepare task variables"
   ansible.builtin.set_fact:
     homarr_service_id: "homarr"
-    homarr_docker_settings: "{{ homarr_docker_settings_default | combine(homarr_docker_settings) }}"
+    homarr_docker_settings: "{{ homarr_docker_settings_default | combine(homarr_docker_settings, recursive=true) }}"
 
 - name: "Make sure config directories exist"
   ansible.builtin.file:

--- a/roles/homarr/vars/main.yml
+++ b/roles/homarr/vars/main.yml
@@ -1,0 +1,17 @@
+---
+homarr_docker_settings_default:
+  network: "host"
+  puid: "1000"
+  pgid: "1000"
+  tz: "Etc/UTC"
+  healthcheck:
+    test: ["CMD", "curl", "--fail", "http://localhost:7575"]
+    interval: 5s
+    timeout: 5s
+    retries: 3
+
+homarr_env_default:
+  TZ: "{{ homarr_docker_settings.tz }}"
+  PUID: "{{ homarr_docker_settings.puid }}"
+  PGID: "{{ homarr_docker_settings.pgid }}"
+  DISABLE_ANALYTICS: "true"

--- a/roles/homarr/vars/main.yml
+++ b/roles/homarr/vars/main.yml
@@ -6,9 +6,9 @@ homarr_docker_settings_default:
   tz: "Etc/UTC"
   healthcheck:
     test: ["CMD", "curl", "--fail", "http://localhost:7575"]
-    start_period: 20s
-    interval: 5s
-    timeout: 5s
+    start_period: 10s
+    interval: 30s
+    timeout: 15s
     retries: 3
 
 homarr_env_default:

--- a/roles/homarr/vars/main.yml
+++ b/roles/homarr/vars/main.yml
@@ -6,6 +6,7 @@ homarr_docker_settings_default:
   tz: "Etc/UTC"
   healthcheck:
     test: ["CMD", "curl", "--fail", "http://localhost:7575"]
+    start_period: 20s
     interval: 5s
     timeout: 5s
     retries: 3

--- a/roles/homebox/tasks/homebox.yml
+++ b/roles/homebox/tasks/homebox.yml
@@ -1,5 +1,6 @@
 # https://hay-kot.github.io/homebox/quick-start/#env-variables-configuration
 ---
+
 - name: "Prepare task variables"
   ansible.builtin.set_fact:
     homebox_service_id: "homebox"
@@ -18,7 +19,6 @@
     networks:
       - name: "{{ homebox_docker_settings.network }}"
     state: "started"
-    healthcheck: "{{ homebox_docker_settings.healthcheck }}"
     env: "{{ homebox_env_default | combine(homebox_env) }}"
     ports:
       - "{{ homebox_webui_port }}:7745"

--- a/roles/homebox/tasks/homebox.yml
+++ b/roles/homebox/tasks/homebox.yml
@@ -1,6 +1,5 @@
 # https://hay-kot.github.io/homebox/quick-start/#env-variables-configuration
 ---
-
 - name: "Prepare task variables"
   ansible.builtin.set_fact:
     homebox_service_id: "homebox"
@@ -19,6 +18,7 @@
     networks:
       - name: "{{ homebox_docker_settings.network }}"
     state: "started"
+    healthcheck: "{{ homebox_docker_settings.healthcheck }}"
     env: "{{ homebox_env_default | combine(homebox_env) }}"
     ports:
       - "{{ homebox_webui_port }}:7745"

--- a/roles/homebox/tasks/homebox.yml
+++ b/roles/homebox/tasks/homebox.yml
@@ -3,7 +3,7 @@
 - name: "Prepare task variables"
   ansible.builtin.set_fact:
     homebox_service_id: "homebox"
-    homebox_docker_settings: "{{ homebox_docker_settings_default | combine(homebox_docker_settings) }}"
+    homebox_docker_settings: "{{ homebox_docker_settings_default | combine(homebox_docker_settings, recursive=true) }}"
 
 - name: "Make sure {{ homebox_docker_settings.network }} docker network exists"
   when: homebox_docker_settings.network != "host"

--- a/roles/homebox/vars/main.yml
+++ b/roles/homebox/vars/main.yml
@@ -4,11 +4,6 @@ homebox_docker_settings_default:
   puid: "1000"
   pgid: "1000"
   tz: "Etc/UTC"
-  healthcheck:
-    test: ["CMD", "curl", "--fail", "http://localhost:7745"]
-    interval: 5s
-    timeout: 5s
-    retries: 3
 
 homebox_env_default:
   TZ: "{{ homebox_docker_settings.tz }}"

--- a/roles/homebox/vars/main.yml
+++ b/roles/homebox/vars/main.yml
@@ -6,6 +6,7 @@ homebox_docker_settings_default:
   tz: "Etc/UTC"
   healthcheck:
     test: ["CMD", "curl", "--fail", "http://localhost:7745"]
+    start_period: 20s
     interval: 5s
     timeout: 5s
     retries: 3

--- a/roles/homebox/vars/main.yml
+++ b/roles/homebox/vars/main.yml
@@ -6,9 +6,9 @@ homebox_docker_settings_default:
   tz: "Etc/UTC"
   healthcheck:
     test: ["CMD", "curl", "--fail", "http://localhost:7745"]
-    start_period: 20s
-    interval: 5s
-    timeout: 5s
+    start_period: 10s
+    interval: 30s
+    timeout: 15s
     retries: 3
 
 homebox_env_default:

--- a/roles/homebox/vars/main.yml
+++ b/roles/homebox/vars/main.yml
@@ -4,6 +4,11 @@ homebox_docker_settings_default:
   puid: "1000"
   pgid: "1000"
   tz: "Etc/UTC"
+  healthcheck:
+    test: ["CMD", "curl", "--fail", "http://localhost:7745"]
+    interval: 5s
+    timeout: 5s
+    retries: 3
 
 homebox_env_default:
   TZ: "{{ homebox_docker_settings.tz }}"

--- a/roles/nginx/tasks/main.yml
+++ b/roles/nginx/tasks/main.yml
@@ -2,7 +2,7 @@
 - name: "Prepare task variables"
   ansible.builtin.set_fact:
     nginx_service_id: "nginx-proxy-manager"
-    nginx_docker_settings: "{{ nginx_docker_settings_default | combine(nginx_docker_settings) }}"
+    nginx_docker_settings: "{{ nginx_docker_settings_default | combine(nginx_docker_settings, recursive=true) }}"
 
 - name: "Make sure config directory exists"
   ansible.builtin.file:

--- a/roles/nginx/tasks/main.yml
+++ b/roles/nginx/tasks/main.yml
@@ -28,6 +28,7 @@
     networks:
       - name: "{{ nginx_docker_settings.network }}"
     state: "started"
+    healthcheck: "{{ nginx_docker_settings.healthcheck }}"
     env: "{{ nginx_env_default | combine(nginx_env) }}"
     ports:
       - "{{ nginx_port_http }}:80"

--- a/roles/nginx/vars/main.yml
+++ b/roles/nginx/vars/main.yml
@@ -4,6 +4,11 @@ nginx_docker_settings_default:
   puid: "1000"
   pgid: "1000"
   tz: "Etc/UTC"
+  healthcheck:
+    test: ["CMD", "/usr/bin/check-health"]
+    interval: 5s
+    timeout: 5s
+    retries: 3
 
 nginx_env_default:
   TZ: "{{ nginx_docker_settings.tz }}"

--- a/roles/olivetin/tasks/main.yml
+++ b/roles/olivetin/tasks/main.yml
@@ -2,7 +2,7 @@
 - name: "Prepare task variables"
   ansible.builtin.set_fact:
     olivetin_service_id: "olivetin"
-    olivetin_docker_settings: "{{ olivetin_docker_settings_default | combine(olivetin_docker_settings) }}"
+    olivetin_docker_settings: "{{ olivetin_docker_settings_default | combine(olivetin_docker_settings, recursive=true) }}"
 
 - name: "Make sure {{ olivetin_docker_settings.network }} docker network exists"
   when: olivetin_docker_settings.network != "host"

--- a/roles/olivetin/tasks/main.yml
+++ b/roles/olivetin/tasks/main.yml
@@ -37,6 +37,7 @@
     networks:
       - name: "{{ olivetin_docker_settings.network }}"
     state: "started"
+    healthcheck: "{{ olivetin_docker_settings.healthcheck }}"
     env: "{{ olivetin_env_default | combine(olivetin_env) }}"
     ports:
       - "{{ olivetin_port }}:1337"

--- a/roles/olivetin/vars/main.yml
+++ b/roles/olivetin/vars/main.yml
@@ -4,6 +4,11 @@ olivetin_docker_settings_default:
   puid: "1000"
   pgid: "1000"
   tz: "Etc/UTC"
+  healthcheck:
+    test: ["CMD", "curl", "--fail", "http://localhost:1337"]
+    interval: 5s
+    timeout: 5s
+    retries: 3
 
 olivetin_env_default:
   TZ: "{{ olivetin_docker_settings.tz }}"

--- a/roles/paperless_ai/tasks/main.yml
+++ b/roles/paperless_ai/tasks/main.yml
@@ -2,7 +2,7 @@
 - name: "Prepare task variables"
   ansible.builtin.set_fact:
     paperless_ai_service_id: "paperless-ai"
-    paperless_ai_docker_settings: "{{ paperless_ai_docker_settings_default | combine(paperless_ai_docker_settings) }}"
+    paperless_ai_docker_settings: "{{ paperless_ai_docker_settings_default | combine(paperless_ai_docker_settings, recursive=true) }}"
 
 - name: "Make sure config directories exist"
   ansible.builtin.file:

--- a/roles/paperless_ai/tasks/main.yml
+++ b/roles/paperless_ai/tasks/main.yml
@@ -27,6 +27,7 @@
     networks:
       - name: "{{ paperless_ai_docker_settings.network }}"
     state: "started"
+    healthcheck: "{{ paperless_ai_docker_settings.healthcheck }}"
     env: "{{ paperless_ai_env_default | combine(paperless_ai_env) }}"
     ports:
       - "{{ paperless_ai_port }}:3000"

--- a/roles/paperless_ai/vars/main.yml
+++ b/roles/paperless_ai/vars/main.yml
@@ -3,6 +3,11 @@ paperless_ai_docker_settings_default:
   puid: "1000"
   pgid: "1000"
   tz: "Etc/UTC"
+  healthcheck:
+    test: ["CMD", "curl", "--fail", "http://localhost:3000"]
+    interval: 5s
+    timeout: 5s
+    retries: 3
 
 paperless_ai_env_default:
   TZ: "{{ paperless_ai_docker_settings.tz }}"

--- a/roles/paperlessngx/tasks/main.yml
+++ b/roles/paperlessngx/tasks/main.yml
@@ -38,6 +38,7 @@
     networks:
       - name: "{{ paperlessngx_docker_settings.network }}"
     state: "started"
+    healthcheck: "{{ paperlessngx_docker_settings.healthcheck }}"
     env: "{{ paperlessngx_env_default | combine(paperlessngx_env) }}"
     ports:
       - "{{ paperlessngx_port }}:8000"

--- a/roles/paperlessngx/tasks/main.yml
+++ b/roles/paperlessngx/tasks/main.yml
@@ -2,7 +2,7 @@
 - name: "Prepare task variables"
   ansible.builtin.set_fact:
     paperlessngx_service_id: "paperlessngx"
-    paperlessngx_docker_settings: "{{ paperlessngx_docker_settings_default | combine(paperlessngx_docker_settings) }}"
+    paperlessngx_docker_settings: "{{ paperlessngx_docker_settings_default | combine(paperlessngx_docker_settings, recursive=true) }}"
 
 - name: "Make sure config directories exist"
   ansible.builtin.file:

--- a/roles/paperlessngx/vars/main.yml
+++ b/roles/paperlessngx/vars/main.yml
@@ -3,6 +3,11 @@ paperlessngx_docker_settings_default:
   puid: "1000"
   pgid: "1000"
   tz: "Etc/UTC"
+  healthcheck:
+    test: ["CMD", "curl", "--fail", "http://localhost:8000"]
+    interval: 5s
+    timeout: 5s
+    retries: 3
 
 paperlessngx_env_default:
   TZ: "{{ paperlessngx_docker_settings.tz }}"

--- a/roles/rss/tasks/main.yml
+++ b/roles/rss/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: "Combine docker_settings with default docker_settings_default"
   ansible.builtin.set_fact:
-    rss_docker_settings: "{{ rss_docker_settings_default | combine(rss_docker_settings) }}"
+    rss_docker_settings: "{{ rss_docker_settings_default | combine(rss_docker_settings, recursive=true) }}"
 
 - name: "Make sure {{ rss_docker_settings.network }} docker network exists"
   when: rss_docker_settings.network != "host"

--- a/roles/rss/tasks/miniflux.yml
+++ b/roles/rss/tasks/miniflux.yml
@@ -20,6 +20,7 @@
     networks:
       - name: "{{ rss_docker_settings.network }}"
     state: "started"
+    healthcheck: "{{ rss_docker_settings.healthcheck }}"
     env: "{{ rss_miniflux_env_default | combine(rss_miniflux_env) }}"
     ports:
       - "{{ rss_miniflux_webui_port }}:8080"

--- a/roles/rss/vars/main.yml
+++ b/roles/rss/vars/main.yml
@@ -4,6 +4,11 @@ rss_docker_settings_default:
   puid: "1000"
   pgid: "1000"
   tz: "Etc/UTC"
+  healthcheck:
+    test: ["CMD", "curl", "--fail", "http://localhost:8080"]
+    interval: 5s
+    timeout: 5s
+    retries: 3
 
 rss_miniflux_db_name: "miniflux"
 rss_miniflux_db_user:

--- a/roles/rss/vars/main.yml
+++ b/roles/rss/vars/main.yml
@@ -6,6 +6,7 @@ rss_docker_settings_default:
   tz: "Etc/UTC"
   healthcheck:
     test: ["CMD", "curl", "--fail", "http://localhost:8080"]
+    start_period: 20s
     interval: 5s
     timeout: 5s
     retries: 3

--- a/roles/rss/vars/main.yml
+++ b/roles/rss/vars/main.yml
@@ -6,9 +6,9 @@ rss_docker_settings_default:
   tz: "Etc/UTC"
   healthcheck:
     test: ["CMD", "curl", "--fail", "http://localhost:8080"]
-    start_period: 20s
-    interval: 5s
-    timeout: 5s
+    start_period: 10s
+    interval: 30s
+    timeout: 15s
     retries: 3
 
 rss_miniflux_db_name: "miniflux"

--- a/roles/vaultwarden/tasks/main.yml
+++ b/roles/vaultwarden/tasks/main.yml
@@ -25,6 +25,7 @@
     networks:
       - name: "{{ vaultwarden_docker_settings.network }}"
     state: "started"
+    healthcheck: "{{ vaultwarden_docker_settings.healthcheck }}"
     env: "{{ vaultwarden_env_default | combine(vaultwarden_env) }}"
     ports:
       - "{{ vaultwarden_port }}:80"

--- a/roles/vaultwarden/tasks/main.yml
+++ b/roles/vaultwarden/tasks/main.yml
@@ -2,7 +2,7 @@
 - name: "Prepare task variables"
   ansible.builtin.set_fact:
     vaultwarden_service_id: "vaultwarden"
-    vaultwarden_docker_settings: "{{ vaultwarden_docker_settings_default | combine(vaultwarden_docker_settings) }}"
+    vaultwarden_docker_settings: "{{ vaultwarden_docker_settings_default | combine(vaultwarden_docker_settings, recursive=true) }}"
 
 - name: "Make sure config directory exists"
   ansible.builtin.file:

--- a/roles/vaultwarden/vars/main.yml
+++ b/roles/vaultwarden/vars/main.yml
@@ -4,6 +4,11 @@ vaultwarden_docker_settings_default:
   puid: "1000"
   pgid: "1000"
   tz: "Etc/UTC"
+  healthcheck:
+    test: ["CMD", "curl", "--fail", "http://localhost:80"]
+    interval: 5s
+    timeout: 5s
+    retries: 3
 
 vaultwarden_env_default:
   TZ: "{{ vaultwarden_docker_settings.tz }}"

--- a/roles/wallos/tasks/wallos.yml
+++ b/roles/wallos/tasks/wallos.yml
@@ -1,6 +1,5 @@
 # https://github.com/ellite/Wallos?tab=readme-ov-file#docker-1
 ---
-
 - name: "Prepare task variables"
   ansible.builtin.set_fact:
     wallos_service_id: "wallos"
@@ -30,6 +29,7 @@
     networks:
       - name: "{{ wallos_docker_settings.network }}"
     state: "started"
+    healthcheck: "{{ wallos_docker_settings.healthcheck }}"
     env: "{{ wallos_env_default | combine(wallos_env) }}"
     ports:
       - "{{ wallos_webui_port }}:80"

--- a/roles/wallos/tasks/wallos.yml
+++ b/roles/wallos/tasks/wallos.yml
@@ -3,7 +3,7 @@
 - name: "Prepare task variables"
   ansible.builtin.set_fact:
     wallos_service_id: "wallos"
-    wallos_docker_settings: "{{ wallos_docker_settings_default | combine(wallos_docker_settings) }}"
+    wallos_docker_settings: "{{ wallos_docker_settings_default | combine(wallos_docker_settings, recursive=true) }}"
 
 - name: "Make sure config directories exist"
   ansible.builtin.file:

--- a/roles/wallos/vars/main.yml
+++ b/roles/wallos/vars/main.yml
@@ -4,6 +4,11 @@ wallos_docker_settings_default:
   puid: "1000"
   pgid: "1000"
   tz: "Etc/UTC"
+  healthcheck:
+    test: ["CMD", "curl", "--fail", "http://localhost:80"]
+    interval: 5s
+    timeout: 5s
+    retries: 3
 
 wallos_env_default:
   TZ: "{{ wallos_docker_settings.tz }}"

--- a/roles/watchtower/tasks/watchtower.yml
+++ b/roles/watchtower/tasks/watchtower.yml
@@ -35,6 +35,7 @@
     networks:
       - name: "{{ watchtower_docker_settings.network }}"
     state: "started"
+    healthcheck: "{{ watchtower_docker_settings.healthcheck }}"
     env: "{{ watchtover_env_default | combine(watchtover_env) }}"
     ports:
       - "{{ watchtower_https_port }}:3443"

--- a/roles/watchtower/tasks/watchtower.yml
+++ b/roles/watchtower/tasks/watchtower.yml
@@ -4,7 +4,7 @@
     watchtower_service_id: "watchtower"
     watchtower_http_port: 80
     watchtower_https_port: 443
-    watchtower_docker_settings: "{{ watchtower_docker_settings_default | combine(watchtower_docker_settings) }}"
+    watchtower_docker_settings: "{{ watchtower_docker_settings_default | combine(watchtower_docker_settings, recursive=true) }}"
 
 - name: "Make sure {{ watchtower_docker_settings.network }} docker network exists"
   when: watchtower_docker_settings.network != "host"

--- a/roles/watchtower/tasks/watchtower.yml
+++ b/roles/watchtower/tasks/watchtower.yml
@@ -35,7 +35,6 @@
     networks:
       - name: "{{ watchtower_docker_settings.network }}"
     state: "started"
-    healthcheck: "{{ watchtower_docker_settings.healthcheck }}"
     env: "{{ watchtover_env_default | combine(watchtover_env) }}"
     ports:
       - "{{ watchtower_https_port }}:3443"

--- a/roles/watchtower/vars/main.yml
+++ b/roles/watchtower/vars/main.yml
@@ -6,6 +6,7 @@ watchtower_docker_settings_default:
   tz: "Etc/UTC"
   healthcheck:
     test: ["CMD", "curl", "--fail", "http://localhost:3080"]
+    start_period: 20s
     interval: 5s
     timeout: 5s
     retries: 3

--- a/roles/watchtower/vars/main.yml
+++ b/roles/watchtower/vars/main.yml
@@ -6,9 +6,9 @@ watchtower_docker_settings_default:
   tz: "Etc/UTC"
   healthcheck:
     test: ["CMD", "curl", "--fail", "http://localhost:3080"]
-    start_period: 20s
+    start_period: 10s
     interval: 5s
-    timeout: 5s
+    timeout: 15s
     retries: 3
 
 watchtover_env_default:

--- a/roles/watchtower/vars/main.yml
+++ b/roles/watchtower/vars/main.yml
@@ -4,6 +4,11 @@ watchtower_docker_settings_default:
   puid: "1000"
   pgid: "1000"
   tz: "Etc/UTC"
+  healthcheck:
+    test: ["CMD", "curl", "--fail", "http://localhost:3080"]
+    interval: 5s
+    timeout: 5s
+    retries: 3
 
 watchtover_env_default:
   TZ: "{{ watchtower_docker_settings.tz }}"

--- a/roles/watchtower/vars/main.yml
+++ b/roles/watchtower/vars/main.yml
@@ -4,11 +4,6 @@ watchtower_docker_settings_default:
   puid: "1000"
   pgid: "1000"
   tz: "Etc/UTC"
-  healthcheck:
-    test: ["CMD", "curl", "--fail", "http://localhost:3080"]
-    interval: 5s
-    timeout: 5s
-    retries: 3
 
 watchtover_env_default:
   TZ: "{{ watchtower_docker_settings.tz }}"

--- a/roles/wgeasy/tasks/main.yml
+++ b/roles/wgeasy/tasks/main.yml
@@ -35,6 +35,7 @@
       - "net_admin"
       - "sys_module"
     state: "started"
+    healthcheck: "{{ wgeasy_docker_settings.healthcheck }}"
     env: "{{ wgeasy_env_default | combine(wgeasy_env) }}"
     ports:
       - "{{ wgeasy_env.WG_PORT }}:{{ wgeasy_env.WG_PORT }}/udp"

--- a/roles/wgeasy/tasks/main.yml
+++ b/roles/wgeasy/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: "Combine docker_settings with docker_settings_default"
   ansible.builtin.set_fact:
-    wgeasy_docker_settings: "{{ wgeasy_docker_settings_default | combine(wgeasy_docker_settings) }}"
+    wgeasy_docker_settings: "{{ wgeasy_docker_settings_default | combine(wgeasy_docker_settings, recursive=true) }}"
 
 - name: "Prepare task variables"
   ansible.builtin.set_fact:

--- a/roles/wgeasy/tasks/main.yml
+++ b/roles/wgeasy/tasks/main.yml
@@ -35,7 +35,6 @@
       - "net_admin"
       - "sys_module"
     state: "started"
-    healthcheck: "{{ wgeasy_docker_settings.healthcheck }}"
     env: "{{ wgeasy_env_default | combine(wgeasy_env) }}"
     ports:
       - "{{ wgeasy_env.WG_PORT }}:{{ wgeasy_env.WG_PORT }}/udp"

--- a/roles/wgeasy/vars/main.yml
+++ b/roles/wgeasy/vars/main.yml
@@ -4,6 +4,11 @@ wgeasy_docker_settings_default:
   puid: "1000"
   pgid: "1000"
   tz: "Etc/UTC"
+  healthcheck:
+    test: ["CMD", "curl", "--fail", "http://localhost:51821"]
+    interval: 5s
+    timeout: 5s
+    retries: 3
 
 wgeasy_env_default:
   TZ: "{{ wgeasy_docker_settings.tz }}"

--- a/roles/wgeasy/vars/main.yml
+++ b/roles/wgeasy/vars/main.yml
@@ -4,11 +4,6 @@ wgeasy_docker_settings_default:
   puid: "1000"
   pgid: "1000"
   tz: "Etc/UTC"
-  healthcheck:
-    test: ["CMD", "curl", "--fail", "http://localhost:51821"]
-    interval: 5s
-    timeout: 5s
-    retries: 3
 
 wgeasy_env_default:
   TZ: "{{ wgeasy_docker_settings.tz }}"

--- a/roles/wgeasy/vars/main.yml
+++ b/roles/wgeasy/vars/main.yml
@@ -6,9 +6,9 @@ wgeasy_docker_settings_default:
   tz: "Etc/UTC"
   healthcheck:
     test: ["CMD", "curl", "--fail", "http://localhost:51821"]
-    start_period: 20s
-    interval: 5s
-    timeout: 5s
+    start_period: 10s
+    interval: 30s
+    timeout: 15s
     retries: 3
 
 wgeasy_env_default:

--- a/roles/wgeasy/vars/main.yml
+++ b/roles/wgeasy/vars/main.yml
@@ -6,6 +6,7 @@ wgeasy_docker_settings_default:
   tz: "Etc/UTC"
   healthcheck:
     test: ["CMD", "curl", "--fail", "http://localhost:51821"]
+    start_period: 20s
     interval: 5s
     timeout: 5s
     retries: 3


### PR DESCRIPTION
This PR aims to add a green checkmark for all the roles testing their installation on Ubuntu 22.04:
- Adds a healthcheck to docker containers
- Adds a workflow to expect the healthcheck to be "healthy" after deploying containers and waiting a bit for docker to collect health stats.
- The workflow tests installation on host and bridge networks, see Actions for status.

## Progress

- [ ] adguardhome (healthcheck="unlealthy")
- [ ] authelia (healthcheck="unhealthy")
- [ ] changedetection (healthcheck="unhealthy")
- [ ] cloudflare. I am not sure if this role can be tested in GH environment at all, but I did some tests and I stuck at the [TUNNEL_ORIGIN_CERT error](https://github.com/artyorsh/ansible-collection-selfhosted/actions/runs/13498266541/job/37710319795). It looks like  it needs to be generated once with `cloudflared tunnel login`.
- [x] docker (the role runs as a pre_task to other roles)
- [x] duplicati
- [x] filebrowser 
- [x] forgejo
- [x] glances 
- [ ] homarr (healthcheck="unhealthy")
- [ ] homebox (healthcheck="unhealthy")
- [ ] rss, miniflux (healthcheck="unhealthy")
- [ ] rss, rssbridge (currently impossible to check, it seems it's better to split the rss role into minixlux + rssbridge)
- [x] nginx
- [x] olivetin
- [x] paperless_ai
- [x] paperlessngx
- [x] vaultwarden
- [x] wallos
- [ ] watchtower (healthcheck="unhealthy")
- [ ] wgeasy (healthcheck="unhealthy")